### PR TITLE
fix(dependabot): change directory for npm analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: daily
     target-branch: develop
   - package-ecosystem: npm
-    directory: /
+    directory: /frontend
     schedule:
       interval: daily
     target-branch: develop


### PR DESCRIPTION
#   Description

Dans une PR précédente je me suis trompé sur le directory pour l'analyse npm du dependabot

#   Task

###### _Link to your task(s) in Jira_

#   Test

- Le job doit être en success

#   PR Dependencies

- None